### PR TITLE
Update default-calendar-list.php

### DIFF
--- a/includes/calendars/views/default-calendar-list.php
+++ b/includes/calendars/views/default-calendar-list.php
@@ -659,7 +659,7 @@ class Default_Calendar_List implements Calendar_View {
 	 * @return bool
 	 */
 	private function filter_events_before( $event ) {
-		return intval( $event ) > intval( $this->start );
+		return intval( $event ) >= intval( $this->start );
 	}
 
 	/**


### PR DESCRIPTION
Google calendar start the day at 12:00am and if the event is today it won't pull and event that start at 12:00 am.

Not sure if this is best fix, but it appears to work.