### PR TITLE
Added filters to allow for customization of calendar header colspan.

### DIFF
--- a/includes/calendars/views/default-calendar-grid.php
+++ b/includes/calendars/views/default-calendar-grid.php
@@ -182,11 +182,11 @@ class Default_Calendar_Grid implements Calendar_View {
 				<thead class="simcal-calendar-head">
 					<tr>
 						<?php if ( ! $calendar->static ) { ?>
-							<th class="simcal-nav simcal-prev-wrapper" colspan="1">
+							<th class="simcal-nav simcal-prev-wrapper" colspan=colspan="<?php echo apply_filters( 'simcal-prev-cols', '1' ); ?>">
 								<button class="simcal-nav-button simcal-month-nav simcal-prev" title="<?php _e( 'Previous Month', 'google-calendar-events' ); ?>"><i class="simcal-icon-left"></i></button>
 							</th>
 						<?php } ?>
-						<th colspan="<?php echo $calendar->static ? '7' : '5'; ?>"
+						<th colspan="<?php echo apply_filters( 'simcal-current-cols', $calendar->static ? '7' : '5' ); ?>"
 						    class="simcal-nav simcal-current"
 						    data-calendar-current="<?php echo $calendar->start; ?>">
 							<?php
@@ -213,7 +213,7 @@ class Default_Calendar_Grid implements Calendar_View {
 							?>
 						</th>
 						<?php if ( ! $calendar->static ) { ?>
-							<th class="simcal-nav simcal-next-wrapper" colspan="1">
+							<th class="simcal-nav simcal-next-wrapper" colspan="<?php echo apply_filters( 'simcal-next-cols', '1' ); ?>">
 								<button class="simcal-nav-button simcal-month-nav simcal-next" title="<?php _e( 'Next Month', 'google-calendar-events' ); ?>"><i class="simcal-icon-right"></i></button>
 							</th>
 						<?php } ?>


### PR DESCRIPTION
Trying to alter the widths of the `.simcal-nav th` for custom designs proves difficult without being able to alter the colspans of the `th`. These filters allow theme developers more control over the layout. 