### PR TITLE
Make .scss files compatible with Sass 3.4

### DIFF
--- a/assets/css/sass/calendars/_default-calendar-grid.scss
+++ b/assets/css/sass/calendars/_default-calendar-grid.scss
@@ -170,7 +170,7 @@
 }
 
 // Event tooltip bubble.
-&.simcal-event-bubble {
+.simcal-event-bubble {
 
   background-color: #fff;
   border: 1px solid rgba(0, 0, 0, .1);


### PR DESCRIPTION
This commit ensures that all .scss files may be compiled using Sass 3.4
without changing the resulting CSS output.