### PR TITLE
Add if-today and if-not-today template tags to Event_Builder

### DIFF
--- a/includes/events/event-builder.php
+++ b/includes/events/event-builder.php
@@ -178,6 +178,11 @@ class Event_Builder {
 			'if-not-ended',
 			// If the event has NOT ended (may as well as not started yet).
 
+			'if-today',
+			// If the event is taking place today
+			'if-not-today',
+			// If the event is NOT taking place today
+
 			'if-whole-day',
 			// If the event lasts the whole day.
 			'if-all-day',
@@ -457,6 +462,24 @@ class Event_Builder {
 							}
 						}
 
+					}
+
+					break;
+
+				case 'if-today' :
+				case 'if-not-today' :
+					$start_dt = $event->start_dt->setTimezone( $calendar->timezone );
+					$start    = $start_dt->getTimestamp();
+
+					$startOfDay = $start_dt->startOfDay()->getTimestamp();
+					$endOfDay = $start_dt->endOfDay()->getTimestamp();
+
+					$today = ( $startOfDay <= $calendar->now ) && ( $calendar->now <= $endOfDay );
+
+					if ( ('if-today' == $tag ) && $today ) {
+						return $calendar->get_event_html( $event, $partial );
+					} elseif ( ( 'if-not-today' == $tag ) && ( false == $today ) ) {
+						return $calendar->get_event_html( $event, $partial );
 					}
 
 					break;


### PR DESCRIPTION
Implements missing functionality described in documentation regarding the `[if-today][/if-today]` template tag. Also adds the `[if-not-today][/if-not-today]` template tag.

From http://docs.simplecalendar.io/event-template-tags/ :
```Additionally, Simple Calendar event template support also conditional tags. To use conditional tags, wrap some content or other content tags (see above) between conditional tags block, like so: [if-today]Your custom content here [description][/if-today]. This will print the description and some text only if the event is happening today.```