### PR TITLE
Fix now option ongoing event issue

### DIFF
--- a/includes/calendars/views/default-calendar-grid.php
+++ b/includes/calendars/views/default-calendar-grid.php
@@ -373,45 +373,34 @@ class Default_Calendar_Grid implements Calendar_View
 					: [];
 
 			$day_events = [];
-			if ('yes' == get_post_meta($calendar->id, '_default_calendar_expand_multi_day_events', true)) {
-				foreach ($filtered as $timestamp => $events_in_day) {
-					foreach ($events_in_day as $event) {
-						if ($event instanceof Event) {
-							$event_start = Carbon::createFromTimestamp($event->start, $calendar->timezone);
-							$event_end = Carbon::createFromTimestamp($event->end, $calendar->timezone);
+			foreach ($filtered as $timestamp => $events_in_day) {
+				foreach ($events_in_day as $event) {
+					if ($event instanceof Event) {
+						$event_start = Carbon::createFromTimestamp($event->start, $calendar->timezone);
+						$event_end = Carbon::createFromTimestamp($event->end, $calendar->timezone);
 
-							for ($day = $event_start->copy(); $day->lte($event_end->endOfDay()); $day->addDay()) {
-								if ($day->month == $current_month && $day->year == $current_year) {
-									$day_key = intval($day->format('j'));
-									$event_id = $event->uid;
-									/*
-									 * The purpose of this condition is to determine if an event ends at the very start of the day.
-									 */
-									if ($day->isSameDay($event_end) && $event_end->hour == 0 && $event_end->minute == 0) {
-										continue;
-									}
+						for ($day = $event_start->copy(); $day->lte($event_end->endOfDay()); $day->addDay()) {
+							if ($day->month == $current_month && $day->year == $current_year) {
+								$day_key = intval($day->format('j'));
+								$event_id = $event->uid;
+								/*
+								 * The purpose of this condition is to determine if an event ends at the very start of the day.
+								 */
+								if ($day->isSameDay($event_end) && $event_end->hour == 0 && $event_end->minute == 0) {
+									continue;
+								}
 
-									if (!isset($day_events[$day_key][$event_id])) {
-										$day_events[$day_key][$event_id] = $event;
-									}
+								if (!isset($day_events[$day_key][$event_id])) {
+									$day_events[$day_key][$event_id] = $event;
 								}
 							}
 						}
 					}
 				}
+			}
 
-				foreach ($day_events as $day_key => $events) {
-					$day_events[$day_key] = array_values($events);
-				}
-			} else {
-				foreach ($filtered as $timestamp => $events_in_day) {
-					foreach ($events_in_day as $event) {
-						if ($event instanceof Event) {
-							$day = intval(Carbon::createFromTimestamp($timestamp, $calendar->timezone)->endOfDay()->day);
-							$day_events[$day][] = $event;
-						}
-					}
-				}
+			foreach ($day_events as $day_key => $events) {
+				$day_events[$day_key] = array_values($events);
 			}
 
 			ksort($day_events, SORT_NUMERIC);

--- a/includes/calendars/views/default-calendar-grid.php
+++ b/includes/calendars/views/default-calendar-grid.php
@@ -373,34 +373,45 @@ class Default_Calendar_Grid implements Calendar_View
 					: [];
 
 			$day_events = [];
-			foreach ($filtered as $timestamp => $events_in_day) {
-				foreach ($events_in_day as $event) {
-					if ($event instanceof Event) {
-						$event_start = Carbon::createFromTimestamp($event->start, $calendar->timezone);
-						$event_end = Carbon::createFromTimestamp($event->end, $calendar->timezone);
+			if ('yes' == get_post_meta($calendar->id, '_default_calendar_expand_multi_day_events', true)) {
+				foreach ($filtered as $timestamp => $events_in_day) {
+					foreach ($events_in_day as $event) {
+						if ($event instanceof Event) {
+							$event_start = Carbon::createFromTimestamp($event->start, $calendar->timezone);
+							$event_end = Carbon::createFromTimestamp($event->end, $calendar->timezone);
 
-						for ($day = $event_start->copy(); $day->lte($event_end->endOfDay()); $day->addDay()) {
-							if ($day->month == $current_month && $day->year == $current_year) {
-								$day_key = intval($day->format('j'));
-								$event_id = $event->uid;
-								/*
-								 * The purpose of this condition is to determine if an event ends at the very start of the day.
-								 */
-								if ($day->isSameDay($event_end) && $event_end->hour == 0 && $event_end->minute == 0) {
-									continue;
-								}
+							for ($day = $event_start->copy(); $day->lte($event_end->endOfDay()); $day->addDay()) {
+								if ($day->month == $current_month && $day->year == $current_year) {
+									$day_key = intval($day->format('j'));
+									$event_id = $event->uid;
+									/*
+									 * The purpose of this condition is to determine if an event ends at the very start of the day.
+									 */
+									if ($day->isSameDay($event_end) && $event_end->hour == 0 && $event_end->minute == 0) {
+										continue;
+									}
 
-								if (!isset($day_events[$day_key][$event_id])) {
-									$day_events[$day_key][$event_id] = $event;
+									if (!isset($day_events[$day_key][$event_id])) {
+										$day_events[$day_key][$event_id] = $event;
+									}
 								}
 							}
 						}
 					}
 				}
-			}
 
-			foreach ($day_events as $day_key => $events) {
-				$day_events[$day_key] = array_values($events);
+				foreach ($day_events as $day_key => $events) {
+					$day_events[$day_key] = array_values($events);
+				}
+			} else {
+				foreach ($filtered as $timestamp => $events_in_day) {
+					foreach ($events_in_day as $event) {
+						if ($event instanceof Event) {
+							$day = intval(Carbon::createFromTimestamp($timestamp, $calendar->timezone)->endOfDay()->day);
+							$day_events[$day][] = $event;
+						}
+					}
+				}
 			}
 
 			ksort($day_events, SORT_NUMERIC);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "google-calendar-events",
   "title": "Simple Calendar",
   "description": "Add Google Calendar events to your WordPress site.",
-  "version": "3.5.4",
+  "version": "3.5.5",
   "license": "GPLv2+",
   "homepage": "https://simplecalendar.io",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "google-calendar-events",
   "title": "Simple Calendar",
   "description": "Add Google Calendar events to your WordPress site.",
-  "version": "3.5.5",
+  "version": "3.5.4",
   "license": "GPLv2+",
   "homepage": "https://simplecalendar.io",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "google-calendar-events",
   "title": "Simple Calendar",
   "description": "Add Google Calendar events to your WordPress site.",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "license": "GPLv2+",
   "homepage": "https://simplecalendar.io",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -97,9 +97,6 @@ We'd love your help! Here's a few things you can do:
 
 == Changelog ==
 
-= 3.5.5 =
-* Fix: "No, display only on first day of event" option in Appearance settings now works as expected.
-
 = 3.5.4 =
 * Fix: The calendar start "Now" option in list view now correctly displays events that have started but not yet ended.
 

--- a/readme.txt
+++ b/readme.txt
@@ -97,6 +97,9 @@ We'd love your help! Here's a few things you can do:
 
 == Changelog ==
 
+= 3.5.4 =
+* Fix: The calendar start "Now" option in list view now correctly displays events that have started but not yet ended.
+
 = 3.5.3 =
 * Fix: Even after upgrading to PHP 8.x, an admin notice still appears to upgrade to PHP8.
 

--- a/readme.txt
+++ b/readme.txt
@@ -97,6 +97,9 @@ We'd love your help! Here's a few things you can do:
 
 == Changelog ==
 
+= 3.5.5 =
+* Fix: "No, display only on first day of event" option in Appearance settings now works as expected.
+
 = 3.5.4 =
 * Fix: The calendar start "Now" option in list view now correctly displays events that have started but not yet ended.
 


### PR DESCRIPTION
**Description:** The "Now" option in list view now correctly displays events that have started but not yet ended. I have added new if condition in list view file  so if the now optin is selected then new code will run and it fix the issue for the other option old will work. the issue was with old code is it does not compare the end time it only check with start time and ongoing event is already started so it was not show on list.
**Clickup:** https://app.clickup.com/t/86cwtk4qx
**Before& after:** https://drive.google.com/file/d/1TUVjMmVRSZ3G6j2NNOHkti-Qed5Yq9yl/view?usp=drivesdk
**Wp topic:** https://wordpress.org/support/topic/start-date-now-not-working/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where calendars set to start "Now" in list view did not correctly display ongoing events that have already started but not yet ended.

- **Documentation**
  - Updated the changelog to reflect the fix for event display in calendars with the "Now" start option.

- **Chores**
  - Incremented the version number to 3.5.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->