### PR TITLE
make compatible plugin with AVADA and other builders

### DIFF
--- a/includes/assets.php
+++ b/includes/assets.php
@@ -46,6 +46,14 @@ class Assets
 	public $disable_styles = false;
 
 	/**
+	 * Flag to track if assets have been scheduled for loading.
+	 *
+	 * @access private
+	 * @var bool
+	 */
+	private static $assets_scheduled = false;
+
+	/**
 	 * Hook in tabs.
 	 *
 	 * @since 3.0.0
@@ -80,15 +88,26 @@ class Assets
 	public function enqueue()
 	{
 		add_action('wp', [$this, 'check_load_assets']);
+
+		// Additional hook for page builders that might process content later
+		add_action('template_redirect', [$this, 'check_load_assets'], 5);
 	}
 
 	/**
 	 * Check if we should load assets.
 	 *
+	 * Enhanced to support all registered shortcodes (calendar, simple_calendar, gcal)
+	 * and detect shortcodes in page builder content including Avada's Fusion Builder.
+	 *
 	 * @since 3.5.6
 	 */
 	public function check_load_assets()
 	{
+		// Prevent duplicate scheduling
+		if (self::$assets_scheduled) {
+			return;
+		}
+
 		// Only load assets if it's a calendar post type or if we detect calendar shortcode
 		$load_assets = false;
 
@@ -98,8 +117,13 @@ class Assets
 
 		if (is_singular() && !$load_assets) {
 			global $post;
-			if (isset($post->post_content) && has_shortcode($post->post_content, 'calendar')) {
-				$load_assets = true;
+			// Check for all registered shortcodes in post content
+			$shortcodes = ['calendar', 'simple_calendar', 'gcal'];
+			foreach ($shortcodes as $shortcode) {
+				if (isset($post->post_content) && has_shortcode($post->post_content, $shortcode)) {
+					$load_assets = true;
+					break;
+				}
 			}
 
 			// Check for shortcodes in Avada builder content and other meta fields
@@ -108,7 +132,13 @@ class Assets
 			}
 		}
 
+		// Also check for shortcodes in widgets and other content areas
+		if (!$load_assets) {
+			$load_assets = $this->check_widgets_and_other_content();
+		}
+
 		if ($load_assets) {
+			self::$assets_scheduled = true;
 			add_action('wp_enqueue_scripts', [$this, 'load'], 10);
 
 			do_action('simcal_enqueue_assets');
@@ -142,10 +172,26 @@ class Assets
 	 */
 	private function check_builder_content($post_id)
 	{
+		$shortcodes = ['calendar', 'simple_calendar', 'gcal'];
+
 		// Check Avada builder content
-		$avada_content = get_post_meta($post_id, '_fusion_builder_content', true);
-		if (!empty($avada_content) && has_shortcode($avada_content, 'calendar')) {
-			return true;
+		// Note: _fusion_builder_content is the standard meta key for Avada's Fusion Builder
+		// Additional Avada meta keys for different versions/builders
+		$avada_meta_keys = [
+			'_fusion_builder_content', // Standard Fusion Builder
+			'_avada_page_options', // Avada page options
+			'_fusion_page_options', // Fusion page options
+		];
+
+		foreach ($avada_meta_keys as $meta_key) {
+			$avada_content = get_post_meta($post_id, $meta_key, true);
+			if (!empty($avada_content)) {
+				foreach ($shortcodes as $shortcode) {
+					if (has_shortcode($avada_content, $shortcode)) {
+						return true;
+					}
+				}
+			}
 		}
 
 		// Check for other common page builder meta fields
@@ -164,12 +210,65 @@ class Assets
 				// For JSON data, decode and search
 				if (is_string($content) && (strpos($content, '{') === 0 || strpos($content, '[') === 0)) {
 					$decoded = json_decode($content, true);
-					if (is_array($decoded) && $this->search_shortcode_in_array($decoded)) {
+					// Check for JSON decode errors
+					if (
+						json_last_error() === JSON_ERROR_NONE &&
+						is_array($decoded) &&
+						$this->search_shortcode_in_array($decoded, $shortcodes)
+					) {
 						return true;
 					}
 				}
-				// For regular content, use has_shortcode
-				elseif (has_shortcode($content, 'calendar')) {
+				// For regular content, check all shortcodes
+				else {
+					foreach ($shortcodes as $shortcode) {
+						if (has_shortcode($content, $shortcode)) {
+							return true;
+						}
+					}
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check for shortcodes in widgets and other content areas.
+	 *
+	 * @since 3.5.6
+	 *
+	 * @return bool True if shortcode found, false otherwise
+	 */
+	private function check_widgets_and_other_content()
+	{
+		$shortcodes = ['calendar', 'simple_calendar', 'gcal'];
+
+		// Check if any widgets contain shortcodes
+		$widgets = get_option('widget_gce_widget');
+		if (!empty($widgets) && is_array($widgets)) {
+			foreach ($widgets as $settings) {
+				if (!empty($settings) && is_array($settings) && isset($settings['calendar_id'])) {
+					return true; // Widget found, assets needed
+				}
+			}
+		}
+
+		// Check theme customizer content
+		$customizer_content = get_theme_mod('custom_css', '');
+		if (!empty($customizer_content)) {
+			foreach ($shortcodes as $shortcode) {
+				if (has_shortcode($customizer_content, $shortcode)) {
+					return true;
+				}
+			}
+		}
+
+		// Check for shortcodes in footer/header content
+		$footer_content = get_theme_mod('footer_text', '');
+		if (!empty($footer_content)) {
+			foreach ($shortcodes as $shortcode) {
+				if (has_shortcode($footer_content, $shortcode)) {
 					return true;
 				}
 			}
@@ -184,14 +283,19 @@ class Assets
 	 * @since 3.5.6
 	 *
 	 * @param array $data Array to search
+	 * @param array $shortcodes Array of shortcodes to search for
 	 * @return bool True if shortcode found, false otherwise
 	 */
-	private function search_shortcode_in_array($data)
+	private function search_shortcode_in_array($data, $shortcodes)
 	{
 		foreach ($data as $key => $value) {
-			if (is_string($value) && has_shortcode($value, 'calendar')) {
-				return true;
-			} elseif (is_array($value) && $this->search_shortcode_in_array($value)) {
+			if (is_string($value)) {
+				foreach ($shortcodes as $shortcode) {
+					if (has_shortcode($value, $shortcode)) {
+						return true;
+					}
+				}
+			} elseif (is_array($value) && $this->search_shortcode_in_array($value, $shortcodes)) {
 				return true;
 			}
 		}

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -94,7 +94,10 @@ class Shortcodes
 
 	/**
 	 * Ensure assets are loaded when shortcode is rendered.
-	 * This handles cases where shortcodes are used in page builders like Avada.
+	 *
+	 * This is a fallback mechanism for cases where the early detection in
+	 * Assets::check_load_assets() might have missed shortcodes in page builders.
+	 * Only schedules assets if wp_enqueue_scripts hasn't fired yet.
 	 *
 	 * @since 3.5.6
 	 */
@@ -105,14 +108,12 @@ class Shortcodes
 			return;
 		}
 
-		// Check if assets are already being loaded
+		// Only schedule early if wp_enqueue_scripts hasn't fired yet
 		if (!did_action('wp_enqueue_scripts')) {
-			// Assets haven't been enqueued yet, so we need to trigger them
 			add_action('wp_enqueue_scripts', [$this, 'load_shortcode_assets'], 5);
-		} else {
-			// Assets have already been enqueued, but we need to ensure they're loaded
-			$this->load_shortcode_assets();
 		}
+		// If wp_enqueue_scripts has already fired, rely on the early detection
+		// mechanism in Assets::check_load_assets() which should have caught this
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "google-calendar-events",
   "title": "Simple Calendar",
   "description": "Add Google Calendar events to your WordPress site.",
-  "version": "3.5.7",
+  "version": "3.5.8",
   "license": "GPLv2+",
   "homepage": "https://simplecalendar.io",
   "repository": {


### PR DESCRIPTION
**Description:** After adding condition for the script load plugins widget is not looking good  due to AVADA theme builder because it store page content in their custom option. so I have added check for the it. and update the condition.

**Clickup:** https://app.clickup.com/t/86d0mzd3a

**Before & After:** https://drive.google.com/file/d/1kEjuET8EpkmpSvs-qJMnD0Wnj4OgdBfq/view?usp=drivesdk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calendar shortcode compatibility with major page builders.
  * Resolved duplicate asset loading and improved shortcode detection in builder content and widgets.

* **New Features**
  * Added a reliable fallback to ensure shortcode assets load in edge cases.
  * Added a public method to explicitly load shortcode assets when needed.

* **Chores**
  * App version bumped to 3.5.8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->