### PR TITLE
Add reverse chronological order option for list view

### DIFF
--- a/includes/calendars/admin/default-calendar-admin.php
+++ b/includes/calendars/admin/default-calendar-admin.php
@@ -224,6 +224,25 @@ class Default_Calendar_Admin
      ?>
 				</td>
 			</tr>
+			<tr class="simcal-panel-field simcal-default-calendar-list" style="display: none;">
+				<th><label for="_default_calendar_reverse_chronological_order"><?php _e('Reverse Chronological Order', 'google-calendar-events'); ?></label></th>
+				<td>
+					<?php
+     $reverse_order = get_post_meta($post_id, '_default_calendar_reverse_chronological_order', true);
+
+     simcal_print_field([
+     	'type' => 'checkbox',
+     	'name' => '_default_calendar_reverse_chronological_order',
+     	'id' => '_default_calendar_reverse_chronological_order',
+     	'tooltip' => __(
+     		'Display events in reverse chronological order (newest first) instead of chronological order (oldest first).',
+     		'google-calendar-events'
+     	),
+     	'value' => 'yes' == $reverse_order ? 'yes' : 'no',
+     ]);
+     ?>
+				</td>
+			</tr>
 			<tr class="simcal-panel-field simcal-default-calendar-grid simcal-default-calendar-list"  style="display: none;">
 				<th><label for="_default_calendar_limit_visible_events"><?php _e(
     	'Limit Visible Events',

--- a/includes/calendars/admin/default-calendar-admin.php
+++ b/includes/calendars/admin/default-calendar-admin.php
@@ -152,7 +152,7 @@ class Default_Calendar_Admin
      ?>
 				</td>
 			</tr>
-			<tr class="simcal-panel-field simcal-default-calendar-list" style="display: none;">
+			<tr class="simcal-panel-field simcal-default-calendar-list test-class" style="display: none;">
 				<th><label for="_default_calendar_list_grouped_span"><?php _e('Span', 'google-calendar-events'); ?></label></th>
 				<td>
 					<?php

--- a/includes/calendars/views/default-calendar-list.php
+++ b/includes/calendars/views/default-calendar-list.php
@@ -390,7 +390,13 @@ class Default_Calendar_List implements Calendar_View
 			}
 		}
 
-		ksort($daily_events, SORT_NUMERIC);
+		// Sort daily events - reverse if reverse chronological order is enabled
+		$reverse_order = get_post_meta($calendar->id, '_default_calendar_reverse_chronological_order', true) == 'yes';
+		if ($reverse_order) {
+			krsort($daily_events, SORT_NUMERIC);
+		} else {
+			ksort($daily_events, SORT_NUMERIC);
+		}
 
 		if (!empty($paged_events)) {
 			$first_event = array_slice($paged_events, 0, 1, true);
@@ -514,16 +520,29 @@ class Default_Calendar_List implements Calendar_View
 	 * @since  3.1.28
 	 * @access private
 	 */
-	private static function cmp($a, $b)
+	private static function cmp($a, $b, $reverse = false)
 	{
 		if ($a->start == $b->start) {
 			if ($a->title == $b->title) {
 				return 0;
 			}
-			return $a->title < $b->title ? -1 : 1;
+			$title_cmp = $a->title < $b->title ? -1 : 1;
+			return $reverse ? -$title_cmp : $title_cmp;
 		} else {
-			return $a->start < $b->start ? -1 : 1;
+			$time_cmp = $a->start < $b->start ? -1 : 1;
+			return $reverse ? -$time_cmp : $time_cmp;
 		}
+	}
+
+	/**
+	 * Comparison function for reverse chronological order.
+	 *
+	 * @since  3.x.x
+	 * @access private
+	 */
+	private function cmp_reverse($a, $b)
+	{
+		return self::cmp($a, $b, true);
 	}
 
 	/**
@@ -549,6 +568,9 @@ class Default_Calendar_List implements Calendar_View
 				return '';
 			}
 		}
+
+		// Check if reverse chronological order is enabled
+		$reverse_order = get_post_meta($calendar->id, '_default_calendar_reverse_chronological_order', true) == 'yes';
 
 		$now = $calendar->now;
 		$current_events = $this->get_events($timestamp);
@@ -660,7 +682,11 @@ class Default_Calendar_List implements Calendar_View
 				$count = 0;
 
 				foreach ($events as $day_events):
-					usort($day_events, [$this, 'cmp']);
+					if ($reverse_order) {
+						usort($day_events, [$this, 'cmp_reverse']);
+					} else {
+						usort($day_events, [$this, 'cmp']);
+					}
 
 					foreach ($day_events as $event):
 						if ($event instanceof Event):


### PR DESCRIPTION
- Add admin setting checkbox for reverse chronological order in list view
- Modify event sorting to support reverse chronological order (newest first)
- Sort both daily events and events within each day in reverse order when enabled
- Fixes issue where calendar settings produce no events in the list

Related to ClickUp task: https://app.clickup.com/t/86cyyzbge