### PR TITLE
Fix constant definition for SIMPLE_CALENDAR_VERSION

### DIFF
--- a/google-calendar-events.php
+++ b/google-calendar-events.php
@@ -21,7 +21,7 @@ if (!defined('ABSPATH')) {
 $this_plugin_path = trailingslashit(dirname(__FILE__));
 $this_plugin_dir = plugin_dir_url(__FILE__);
 $this_plugin_constants = [
-	'SIMPLE_CALENDAR_VERSION' => PACKAGE_VERSION,
+	'SIMPLE_CALENDAR_VERSION' => 'PACKAGE_VERSION',
 	'SIMPLE_CALENDAR_MAIN_FILE' => __FILE__,
 	'SIMPLE_CALENDAR_URL' => $this_plugin_dir,
 	'SIMPLE_CALENDAR_ASSETS' => $this_plugin_dir . 'assets/',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plugin version constant definition to ensure accurate version identification across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Xtendify/Simple-Calendar/pull/685)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->