### PR TITLE
Text domain Notice and GSC error

### DIFF
--- a/includes/feeds/google.php
+++ b/includes/feeds/google.php
@@ -6,9 +6,12 @@
  */
 namespace SimpleCalendar\Feeds;
 
+use SimpleCalendar\plugin_deps\Google\Collection as Google_Collection;
+use SimpleCalendar\plugin_deps\Google\Model as Google_Model;
 use SimpleCalendar\plugin_deps\Google\Service\Calendar as Google_Service_Calendar;
 use SimpleCalendar\plugin_deps\Google\Client as Google_Client;
 use SimpleCalendar\plugin_deps\Google\Service\Calendar\Event as Google_Service_Calendar_Event;
+use SimpleCalendar\plugin_deps\Google\Service\Calendar\EventDateTime as Google_Service_Calendar_EventDateTime;
 use SimpleCalendar\plugin_deps\Google\Service\Calendar\Events as Google_Service_Calendar_Events;
 use SimpleCalendar\plugin_deps\Google\Service\Exception as Google_Service_Exception;
 
@@ -588,7 +591,7 @@ class Google extends Feed
 					throw new Google_Service_Exception($message, 1);
 				}
 
-				$response = unserialize($response_arr['data'], ['allowed_classes' => true]);
+				$response = $this->oauth_unserialize_events_response($response_arr['data']);
 				if (isset($response_arr['backgroundcolor']) && !empty($response_arr['backgroundcolor'])) {
 					$backgroundcolor = $response_arr['backgroundcolor'];
 				}
@@ -614,6 +617,27 @@ class Google extends Feed
 		}
 
 		return $calendar;
+	}
+
+	/**
+	 * Unserialize OAuth proxy events response with a restricted class allowlist.
+	 *
+	 * @since  3.5.4
+	 *
+	 * @param string $data Serialized events payload from the auth proxy.
+	 * @return mixed
+	 */
+	private function oauth_unserialize_events_response($data)
+	{
+		return unserialize($data, [
+			'allowed_classes' => [
+				Google_Service_Calendar_Events::class,
+				Google_Service_Calendar_Event::class,
+				Google_Service_Calendar_EventDateTime::class,
+				Google_Model::class,
+				Google_Collection::class,
+			],
+		]);
 	}
 
 	/**

--- a/includes/feeds/google.php
+++ b/includes/feeds/google.php
@@ -11,7 +11,20 @@ use SimpleCalendar\plugin_deps\Google\Model as Google_Model;
 use SimpleCalendar\plugin_deps\Google\Service\Calendar as Google_Service_Calendar;
 use SimpleCalendar\plugin_deps\Google\Client as Google_Client;
 use SimpleCalendar\plugin_deps\Google\Service\Calendar\Event as Google_Service_Calendar_Event;
+use SimpleCalendar\plugin_deps\Google\Service\Calendar\EventAttendee as Google_Service_Calendar_EventAttendee;
+use SimpleCalendar\plugin_deps\Google\Service\Calendar\EventAttachment as Google_Service_Calendar_EventAttachment;
+use SimpleCalendar\plugin_deps\Google\Service\Calendar\EventBirthdayProperties as Google_Service_Calendar_EventBirthdayProperties;
+use SimpleCalendar\plugin_deps\Google\Service\Calendar\EventCreator as Google_Service_Calendar_EventCreator;
 use SimpleCalendar\plugin_deps\Google\Service\Calendar\EventDateTime as Google_Service_Calendar_EventDateTime;
+use SimpleCalendar\plugin_deps\Google\Service\Calendar\EventExtendedProperties as Google_Service_Calendar_EventExtendedProperties;
+use SimpleCalendar\plugin_deps\Google\Service\Calendar\EventFocusTimeProperties as Google_Service_Calendar_EventFocusTimeProperties;
+use SimpleCalendar\plugin_deps\Google\Service\Calendar\EventGadget as Google_Service_Calendar_EventGadget;
+use SimpleCalendar\plugin_deps\Google\Service\Calendar\EventOrganizer as Google_Service_Calendar_EventOrganizer;
+use SimpleCalendar\plugin_deps\Google\Service\Calendar\EventOutOfOfficeProperties as Google_Service_Calendar_EventOutOfOfficeProperties;
+use SimpleCalendar\plugin_deps\Google\Service\Calendar\EventReminder as Google_Service_Calendar_EventReminder;
+use SimpleCalendar\plugin_deps\Google\Service\Calendar\EventReminders as Google_Service_Calendar_EventReminders;
+use SimpleCalendar\plugin_deps\Google\Service\Calendar\EventSource as Google_Service_Calendar_EventSource;
+use SimpleCalendar\plugin_deps\Google\Service\Calendar\EventWorkingLocationProperties as Google_Service_Calendar_EventWorkingLocationProperties;
 use SimpleCalendar\plugin_deps\Google\Service\Calendar\Events as Google_Service_Calendar_Events;
 use SimpleCalendar\plugin_deps\Google\Service\Exception as Google_Service_Exception;
 
@@ -633,7 +646,20 @@ class Google extends Feed
 			'allowed_classes' => [
 				Google_Service_Calendar_Events::class,
 				Google_Service_Calendar_Event::class,
+				Google_Service_Calendar_EventAttendee::class,
+				Google_Service_Calendar_EventAttachment::class,
+				Google_Service_Calendar_EventBirthdayProperties::class,
+				Google_Service_Calendar_EventCreator::class,
 				Google_Service_Calendar_EventDateTime::class,
+				Google_Service_Calendar_EventExtendedProperties::class,
+				Google_Service_Calendar_EventFocusTimeProperties::class,
+				Google_Service_Calendar_EventGadget::class,
+				Google_Service_Calendar_EventOrganizer::class,
+				Google_Service_Calendar_EventOutOfOfficeProperties::class,
+				Google_Service_Calendar_EventReminder::class,
+				Google_Service_Calendar_EventReminders::class,
+				Google_Service_Calendar_EventSource::class,
+				Google_Service_Calendar_EventWorkingLocationProperties::class,
 				Google_Model::class,
 				Google_Collection::class,
 			],

--- a/includes/feeds/google.php
+++ b/includes/feeds/google.php
@@ -570,12 +570,30 @@ class Google extends Feed
 			) {
 				$response_arr = apply_filters('simple_calendar_oauth_list_events', '', $id, $args);
 
-				$response = unserialize($response_arr['data']);
+				if (!is_array($response_arr)) {
+					throw new Google_Service_Exception(
+						__('Unable to fetch calendar events via OAuth.', 'google-calendar-events'),
+						1,
+					);
+				}
+
+				if (isset($response_arr['Error']) && !empty($response_arr['Error'])) {
+					throw new Google_Service_Exception($response_arr['Error'], 1);
+				}
+
+				if (!isset($response_arr['data']) || !is_string($response_arr['data']) || $response_arr['data'] === '') {
+					$message = !empty($response_arr['message'])
+						? (string) $response_arr['message']
+						: __('Unable to fetch calendar events via OAuth.', 'google-calendar-events');
+					throw new Google_Service_Exception($message, 1);
+				}
+
+				$response = unserialize($response_arr['data'], ['allowed_classes' => true]);
 				if (isset($response_arr['backgroundcolor']) && !empty($response_arr['backgroundcolor'])) {
 					$backgroundcolor = $response_arr['backgroundcolor'];
 				}
 
-				if (isset($response['Error']) && !empty($response['Error'])) {
+				if (is_array($response) && isset($response['Error']) && !empty($response['Error'])) {
 					throw new Google_Service_Exception($response['Error'], 1);
 				}
 			} else {

--- a/includes/main.php
+++ b/includes/main.php
@@ -124,6 +124,9 @@ final class Plugin
 			add_action('admin_init', [$this, 'maybe_redirect_to_connect'], 1);
 		}
 
+		// Load translations before other init callbacks that use __().
+		add_action('init', [$this, 'load_plugin_textdomain'], 1);
+
 		// Init hooks.
 		add_action('init', [$this, 'init'], 5);
 		add_action('admin_init', [$this, 'register_settings'], 5);
@@ -214,9 +217,6 @@ final class Plugin
 	{
 		// Before init action hook.
 		do_action('before_simcal_init');
-
-		// Set up localization.
-		add_action('plugins_loaded', [$this, 'load_plugin_textdomain']);
 
 		// Init objects factory.
 		$this->objects = new Objects();

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "google-calendar-events",
   "title": "Simple Calendar",
   "description": "Add Google Calendar events to your WordPress site.",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "license": "GPLv2+",
   "homepage": "https://simplecalendar.io",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -98,6 +98,10 @@ We'd love your help! Here's a few things you can do:
 == Changelog ==
 
 = 4.0.3 =
+* Fix: Fixed text domain loading by hooking into init.
+* Dev: Added validation before unserialize() to prevent errors during OAuth failures.
+
+= 4.0.3 =
 * Dev: Ensured compatibility with WordPress 7.0.
 * Fix: Trimmed historical changelog entries to resolve WordPress.org length warnings.
 * Dev: Add an [if-event] conditional template tag


### PR DESCRIPTION
**Description:** Fixed the text domain notice by hooking it to the init action so it loads correctly. Also added missing validation before unserialize() when OAuth fails. Previously, unserialize() was still being called during an OAuth failure, leading to failed requests—specifically when a user connected via SC. While this bug may contribute to the issue, the root cause ultimately lies within the proxy add-on.
Clickup: https://app.clickup.com/t/1867958/86d34u7yd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed translation loading timing by initializing localization earlier during the WordPress boot sequence.

* **Improvements**
  * Strengthened feed response handling with stricter validation of OAuth/proxy results.
  * Improved error reporting when feed retrieval or decoding fails.
  * Enhanced safety around processing external feed payloads to prevent unexpected values from propagating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->