### PR TITLE
PHP8.3 Compatibility issue

### DIFF
--- a/includes/admin/pages/connect/partials/google-calendar-api-key-connect.php
+++ b/includes/admin/pages/connect/partials/google-calendar-api-key-connect.php
@@ -132,22 +132,18 @@ $api_key_field_item_class = $is_credentials_core ? 'sc_item sc_core_item_spaced'
 		<div class="sc_connect_helper_row">
 			<p class="sc_connect_helper_text">
 				<?php
-    /* translators: %1$s: Opening anchor tag, %2$s: Closing anchor tag */
-    $text = __('To create one, follow our&nbsp; %1$sstep-by-step guide%2$s.', 'google-calendar-events');
+    $guide_url = simcal_ga_campaign_url(
+    	'https://docs.simplecalendar.io/google-api-key',
+    	'core-plugin',
+    	'connect-api-key-docs',
+    );
     echo wp_kses(
-    	sprintf(
-    		$text,
-    		'<a href="' .
-    			esc_url(
-    				simcal_ga_campaign_url(
-    					'https://docs.simplecalendar.io/google-api-key',
-    					'core-plugin',
-    					'connect-api-key-docs',
-    				),
-    			) .
-    			'" target="_blank" class="sc_connect_helper_link">',
-    		'</a>',
-    	),
+    	esc_html__('To create one, follow our', 'google-calendar-events') .
+    		'&nbsp; <a href="' .
+    		esc_url($guide_url) .
+    		'" target="_blank" class="sc_connect_helper_link">' .
+    		esc_html__('step-by-step guide', 'google-calendar-events') .
+    		'</a>.',
     	[
     		'a' => [
     			'href' => true,

--- a/includes/admin/pages/connect/steps/pro-credentials.php
+++ b/includes/admin/pages/connect/steps/pro-credentials.php
@@ -226,14 +226,15 @@ $google_pro_defs =
    ob_start();
    ?>
 			<p class="sc_connect_helper_text sc_connect_credentials_step_help">
-			<?php echo sprintf(
-   	__(
-   		'To create one, follow our&nbsp; %1$sstep-by-step guide%2$s to configure Google OAuth client.',
-   		'google-calendar-events',
-   	),
-   	'<a href="' . esc_url($step_by_step_url) . '" target="_blank" class="sc_connect_helper_link">',
-   	'</a>',
-   ); ?>
+			<?php
+   echo esc_html__('To create one, follow our', 'google-calendar-events') .
+   	'&nbsp; <a href="' .
+   	esc_url($step_by_step_url) .
+   	'" target="_blank" class="sc_connect_helper_link">' .
+   	esc_html__('step-by-step guide', 'google-calendar-events') .
+   	'</a> ' .
+   	esc_html__('to configure Google OAuth client.', 'google-calendar-events');
+   ?>
 			</p>
 			<?php
    $field_after = [

--- a/includes/admin/pages/connect/steps/pro-credentials.php
+++ b/includes/admin/pages/connect/steps/pro-credentials.php
@@ -226,15 +226,13 @@ $google_pro_defs =
    ob_start();
    ?>
 			<p class="sc_connect_helper_text sc_connect_credentials_step_help">
-			<?php
-   echo esc_html__('To create one, follow our', 'google-calendar-events') .
+			<?php echo esc_html__('To create one, follow our', 'google-calendar-events') .
    	'&nbsp; <a href="' .
    	esc_url($step_by_step_url) .
    	'" target="_blank" class="sc_connect_helper_link">' .
    	esc_html__('step-by-step guide', 'google-calendar-events') .
    	'</a> ' .
-   	esc_html__('to configure Google OAuth client.', 'google-calendar-events');
-   ?>
+   	esc_html__('to configure Google OAuth client.', 'google-calendar-events'); ?>
 			</p>
 			<?php
    $field_after = [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "google-calendar-events",
   "title": "Simple Calendar",
   "description": "Add Google Calendar events to your WordPress site.",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "license": "GPLv2+",
   "homepage": "https://simplecalendar.io",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -97,7 +97,10 @@ We'd love your help! Here's a few things you can do:
 
 == Changelog ==
 
-= 4.0.3 =
+= 4.0.5 =
+* Fix: Fixed a PHP 8.3 ValueError by replacing sprintf() with string concatenation to safely handle literal percent signs in translations.
+
+= 4.0.4 =
 * Fix: Fixed text domain loading by hooking into init.
 * Dev: Added validation before unserialize() to prevent errors during OAuth failures.
 


### PR DESCRIPTION
Description: Root cause: On PHP 8.3, sprintf() throws a ValueError when the format string contains a % that isn’t a valid placeholder. On line 138, the string from __() was passed straight into sprintf():

Build the helper text without sprintf() on the translatable string — separate translatable fragments, concatenate the link in code, and keep wp_kses() for the anchor tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Google Calendar setup helper text to avoid a PHP 8.3 `ValueError` related to translated percent signs.
  * Improved how the step-by-step guide link is constructed in the Google OAuth/connect screens while preserving the same destination and appearance.
* **Documentation**
  * Updated the README changelog with the 4.0.5 note for the PHP 8.3 fix.
* **Chores**
  * Bumped the package version to 4.0.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->