### PR TITLE
Remove requirement of API key for creating group calendar

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -212,13 +212,13 @@
 					hasGoogleApiKey = String(settingsContentWrap.data('sc-has-google-api-key')) === '1',
 					hasProAuth = String(settingsContentWrap.data('sc-has-pro-auth')) === '1',
 					requiredFeedsRaw = settingsContentWrap.attr('data-sc-api-key-required-feeds'),
-					requiredFeeds = ['google', 'grouped-calendars'];
+					requiredFeeds = ['google'];
 
 				if (requiredFeedsRaw) {
 					try {
 						requiredFeeds = JSON.parse(requiredFeedsRaw);
 					} catch (e) {
-						requiredFeeds = ['google', 'grouped-calendars'];
+						requiredFeeds = ['google'];
 					}
 				}
 

--- a/includes/admin/metaboxes/settings.php
+++ b/includes/admin/metaboxes/settings.php
@@ -52,11 +52,7 @@ class Settings implements Meta_Box
 		$has_own_oauth = !empty(trim((string) get_option('simple-calendar_google-pro-token', '')));
 		$has_pro_auth = $has_oauth_via_simple_calendar || $has_own_oauth;
 
-		$feed_types_needing_api_key = apply_filters('simcal_feed_types_requiring_google_api_key', [
-			'google',
-			'grouped-calendars',
-			'grouped-calendar',
-		]);
+		$feed_types_needing_api_key = apply_filters('simcal_feed_types_requiring_google_api_key', ['google']);
 		$feed_types_needing_api_key = array_values(
 			array_unique(array_map('sanitize_title', (array) $feed_types_needing_api_key)),
 		);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "google-calendar-events",
   "title": "Simple Calendar",
   "description": "Add Google Calendar events to your WordPress site.",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "license": "GPLv2+",
   "homepage": "https://simplecalendar.io",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -97,6 +97,9 @@ We'd love your help! Here's a few things you can do:
 
 == Changelog ==
 
+= 4.0.7 =
+* Fix: Removed unnecessary Google API key/OAuth requirement when creating a Grouped Calendar.
+
 = 4.0.6 =
 * Fix: Optimize admin & fronend performance, throttle OAuth token checks, and reduce redundant API calls.
 


### PR DESCRIPTION
Description: Allowed Grouped Calendars to be created without requiring a Google API key or OAuth, as they only combine existing calendars and do not fetch external feeds.
Clickup: https://app.clickup.com/t/1867958/86d3e1jte
Before: https://drive.google.com/file/d/1h0PlLaMUA2JnIEeBJg76k4rX8ygisOu_/view?usp=drivesdk
After: https://drive.google.com/file/d/1u1x8DOMm4Affg-yU9L-mG792NZ_GIEZN/view?usp=drivesdk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed an unnecessary Google API key/OAuth prompt when creating a Grouped Calendar.
  - Improved settings behavior so only Google-related feeds trigger the masked API key fields in the fallback path.

- **Chores**
  - Updated the app version to **4.0.7**.

- **Documentation**
  - Added a changelog entry for version **4.0.7**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->