### PR TITLE
Prevent duplicate system status report rendering

### DIFF
--- a/includes/admin/pages/system-status.php
+++ b/includes/admin/pages/system-status.php
@@ -22,6 +22,18 @@ if (!defined('ABSPATH')) {
 class System_Status extends Admin_Page
 {
 	/**
+	 * Whether the report has been rendered in the current request.
+	 *
+	 * Each active add-on bootstraps the Tools page again, creating another
+	 * instance of this class that hooks another copy of `html()` onto the
+	 * same action. Shared across instances so the report prints only once.
+	 *
+	 * @access private
+	 * @var bool
+	 */
+	private static $rendered = false;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 3.0.0
@@ -51,6 +63,10 @@ class System_Status extends Admin_Page
 	 */
 	public function html()
 	{
+		if (self::$rendered) {
+			return;
+		}
+		self::$rendered = true;
 		?>
 		<div id="simcal-system-status-report">
 			<p><?php _e('Please copy and paste this information when contacting support:', 'google-calendar-events'); ?> </p>


### PR DESCRIPTION
## Summary
Fixes an issue where the system status report was being rendered multiple times when active add-ons bootstrap the Tools page, causing duplicate output in the admin interface.

## Key Changes
- Added a static `$rendered` flag to the `System_Status` class to track whether the report has already been rendered in the current request
- Added an early return in the `html()` method that checks this flag before rendering, ensuring the report only prints once even when multiple instances of the class are created
- The flag is shared across all instances of the class within a single request lifecycle

## Implementation Details
The solution leverages a static class variable that persists across multiple instantiations of the `System_Status` class within the same request. When each active add-on bootstraps the Tools page, it creates a new instance that would normally hook another copy of the `html()` method to the same action. With this change, only the first instance will render the report, while subsequent instances will exit early, preventing duplicate output.

https://claude.ai/code/session_01QbW2VafjHdBY3tGvqgrbMK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate system status reports from appearing when multiple add-on instances are active during the same request.
  * Ensured the status page renders only once per load, improving clarity and avoiding repeated content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->