### PR TITLE
updated stale actions

### DIFF
--- a/.github/workflows/close_stale.yml
+++ b/.github/workflows/close_stale.yml
@@ -4,10 +4,12 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
+  actions: write
 
 on:
   schedule:
     - cron: '30 11 * * *'
+  workflow_dispatch:
 
 jobs:
   stale:

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -691,10 +691,7 @@
 				})
 				.fail(function (xhr) {
 					var message =
-						xhr &&
-						xhr.responseJSON &&
-						xhr.responseJSON.data &&
-						xhr.responseJSON.data.message
+						xhr && xhr.responseJSON && xhr.responseJSON.data && xhr.responseJSON.data.message
 							? xhr.responseJSON.data.message
 							: 'The ICS file could not be uploaded.';
 					status.text(message).css('color', '#b32d2e').show();

--- a/includes/admin/ajax.php
+++ b/includes/admin/ajax.php
@@ -198,14 +198,19 @@ class Ajax
 			wp_send_json_error(['message' => __('No ICS file was selected.', 'google-calendar-events')], 400);
 		}
 
-		$upload_error = isset($_FILES['_ics_feed_file']['error']) ? (int) $_FILES['_ics_feed_file']['error'] : UPLOAD_ERR_OK;
+		$upload_error = isset($_FILES['_ics_feed_file']['error'])
+			? (int) $_FILES['_ics_feed_file']['error']
+			: UPLOAD_ERR_OK;
 
 		if (UPLOAD_ERR_INI_SIZE === $upload_error || UPLOAD_ERR_FORM_SIZE === $upload_error) {
 			wp_send_json_error(
 				[
 					'message' => sprintf(
 						/* translators: %s: maximum upload file size */
-						__('The ICS file is too large. Please increase the PHP upload limit (currently %s) or upload a smaller file.', 'google-calendar-events'),
+						__(
+							'The ICS file is too large. Please increase the PHP upload limit (currently %s) or upload a smaller file.',
+							'google-calendar-events',
+						),
 						size_format(wp_max_upload_size()),
 					),
 				],

--- a/includes/feeds/admin/ics-feed-admin.php
+++ b/includes/feeds/admin/ics-feed-admin.php
@@ -125,16 +125,15 @@ class Ics_Feed_Admin
 				<thead>
 					<tr><th colspan="2"><?php _e('ICS Feed Settings', 'google-calendar-events'); ?></th></tr>
 				</thead>
-				  <?php
-				  /**
-		 * Add ICS feed source fields before the file upload (e.g. live URL in Pro).
-		 *
-		 * @since 4.1.0
-		 *
-		 * @param int $post_id Calendar post ID.
-		 */
+				  <?php /**
+       * Add ICS feed source fields before the file upload (e.g. live URL in Pro).
+       *
+       * @since 4.1.0
+       *
+       * @param int $post_id Calendar post ID.
+       */
 
-		do_action('simcal_ics_feed_settings_fields_before', $post_id); ?>
+      do_action('simcal_ics_feed_settings_fields_before', $post_id); ?>
 				<tbody class="simcal-panel-section simcal-panel-section-ics-feed-file">
 					<tr class="simcal-panel-field">
 						<th>
@@ -144,15 +143,15 @@ class Ics_Feed_Admin
 						</th>
 						<td>
 							<div class="simcal-ics-source-fields">
-							 <?php /**
-         * Used by ICS Feed Pro to place its URL field beside the file input.
-         *
-         * @since 4.1.0
-         *
-         * @param int $post_id Calendar post ID.
-         */
+							  /**
+		 * Used by ICS Feed Pro to place its URL field beside the file input.
+		 *
+		 * @since 4.1.0
+		 *
+		 * @param int $post_id Calendar post ID.
+		 */<?php
 
-        do_action('simcal_ics_feed_file_field_before', $post_id); ?>
+		do_action('simcal_ics_feed_file_field_before', $post_id); ?>
 								<div class="simcal-ics-file-source" <?php echo $hide_file_source ? 'hidden' : ''; ?>>
 									<input
 										type="file"
@@ -278,11 +277,7 @@ class Ics_Feed_Admin
 	 */
 	public static function ics_source_field_help()
 	{
-		$docs_url = simcal_ga_campaign_url(
-			simcal_get_url('docs') . '/ics-feed/',
-			'core-plugin',
-			'settings-link',
-		);
+		$docs_url = simcal_ga_campaign_url(simcal_get_url('docs') . '/ics-feed/', 'core-plugin', 'settings-link');
 
 		return sprintf(
 			'<p class="description">' .

--- a/includes/feeds/admin/ics-feed-admin.php
+++ b/includes/feeds/admin/ics-feed-admin.php
@@ -131,9 +131,7 @@ class Ics_Feed_Admin
 		 * @since 4.1.0
 		 *
 		 * @param int $post_id Calendar post ID.
-		 */<?php
-
-		do_action('simcal_ics_feed_settings_fields_before', $post_id); ?>
+		 */<?php do_action('simcal_ics_feed_settings_fields_before', $post_id); ?>
 				<tbody class="simcal-panel-section simcal-panel-section-ics-feed-file">
 					<tr class="simcal-panel-field">
 						<th>

--- a/includes/feeds/admin/ics-feed-admin.php
+++ b/includes/feeds/admin/ics-feed-admin.php
@@ -125,15 +125,15 @@ class Ics_Feed_Admin
 				<thead>
 					<tr><th colspan="2"><?php _e('ICS Feed Settings', 'google-calendar-events'); ?></th></tr>
 				</thead>
-				  <?php /**
-       * Add ICS feed source fields before the file upload (e.g. live URL in Pro).
-       *
-       * @since 4.1.0
-       *
-       * @param int $post_id Calendar post ID.
-       */
+				   /**
+		 * Add ICS feed source fields before the file upload (e.g. live URL in Pro).
+		 *
+		 * @since 4.1.0
+		 *
+		 * @param int $post_id Calendar post ID.
+		 */<?php
 
-      do_action('simcal_ics_feed_settings_fields_before', $post_id); ?>
+		do_action('simcal_ics_feed_settings_fields_before', $post_id); ?>
 				<tbody class="simcal-panel-section simcal-panel-section-ics-feed-file">
 					<tr class="simcal-panel-field">
 						<th>
@@ -149,9 +149,7 @@ class Ics_Feed_Admin
 		 * @since 4.1.0
 		 *
 		 * @param int $post_id Calendar post ID.
-		 */<?php
-
-		do_action('simcal_ics_feed_file_field_before', $post_id); ?>
+		 */<?php do_action('simcal_ics_feed_file_field_before', $post_id); ?>
 								<div class="simcal-ics-file-source" <?php echo $hide_file_source ? 'hidden' : ''; ?>>
 									<input
 										type="file"

--- a/includes/feeds/ics-feed.php
+++ b/includes/feeds/ics-feed.php
@@ -212,7 +212,10 @@ class Ics_Feed extends Feed
 				'ics_file_too_large',
 				sprintf(
 					/* translators: %s: maximum upload file size */
-					__('The ICS file is too large. Please increase the PHP upload limit (currently %s) or upload a smaller file.', 'google-calendar-events'),
+					__(
+						'The ICS file is too large. Please increase the PHP upload limit (currently %s) or upload a smaller file.',
+						'google-calendar-events',
+					),
 					size_format(wp_max_upload_size()),
 				),
 			);


### PR DESCRIPTION
**Description ::** Issues were getting marked as stale but never actually closed.

The stale action saves a temporary file between runs to keep track of what it
has already looked at. It's supposed to clear that file when it finishes, but it
didn't have permission to do so. The leftover file stuck around, and on every run
after that the action assumed all stale issues had already been handled and
skipped right past them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for manually running the stale-item cleanup workflow.
  * Updated workflow permissions to enable required automated actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->