### PR TITLE
Restrict Renovate to Monday-only dependency PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"]
+  "extends": ["local>Xtendify/renovate-config"]
 }


### PR DESCRIPTION
Moves this repo's Renovate config to the shared org preset [`Xtendify/renovate-config`](https://github.com/Xtendify/renovate-config), which pins dependency updates to a **Monday-only** window.

- New dependency PRs are opened only Monday 00:00–03:59 `Asia/Kolkata` (`schedule:weekly`).
- Existing open Renovate PRs are still rebased during the week (`updateNotScheduled` stays at its default `true`), so nothing goes stale.
- `config:recommended` moves into the preset — behaviour is otherwise unchanged.

Future policy changes are now a one-file edit in the preset repo instead of six.

> [!IMPORTANT]
> Renovate must be granted access to the private `renovate-config` repo in the org app installation **before** this merges, otherwise config resolution fails here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency maintenance configuration to use the latest shared configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->