### PR TITLE
fix: keep event bubbles working after cancelling print

### DIFF
--- a/assets/js/default-calendar.js
+++ b/assets/js/default-calendar.js
@@ -412,15 +412,16 @@ jQuery(function ($) {
 			return;
 		}
 
-		var $divToPrint = $calendar.clone(true);
-		$('body').children().hide();
+		var $divToPrint = $calendar.clone(false);
+		var $toHide = $('body').children().not('script').filter(':visible');
+		$toHide.hide();
 		$('body').append($divToPrint);
 		$('body').addClass('simcal-print-calendar');
 
 		window.print();
 
-		$('body > .simcal-calendar').remove();
-		$('body').children().not('script').show();
+		$divToPrint.remove();
+		$toHide.show();
 		$('body').removeClass('simcal-print-calendar');
 	});
 


### PR DESCRIPTION
**Task**:: [Print Overlay Persists After Cancelling Print Dialog](https://app.clickup.com/t/1867958/86d3eh3jp)

**Description**:: 
Before: Print cloned the calendar with all its tip data (clone(true)), hid the page, then after cancel showed every body child again. That pulled dormant qTip layers back on top of the calendar, so some events stopped responding to hover/click.

After: We clone without that tip data, and we only put back what we actually hid. Tips that were meant to stay hidden stay hidden, so events work again after Cancel.

Touched: assets/js/default-calendar.js

**Before**:: [Link](https://drive.google.com/file/d/1M-BH6cYSYl2bNEdu5oALkLC-1VZjPpzE/view)
**After**:: [Link](https://www.awesomescreenshot.com/video/55344218?key=5f46c98a3f0be615ccfa4c5e8357b649)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar printing behavior.
  * Preserved the visibility state of page elements after printing.
  * Prevented hidden elements from being unintentionally shown when printing completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->