### PR TITLE
fix: handle array ids in bulk action admin notices

### DIFF
--- a/includes/admin/bulk-actions.php
+++ b/includes/admin/bulk-actions.php
@@ -201,7 +201,8 @@ class Bulk_Actions
 		global $post_type, $pagenow;
 
 		if (isset($_REQUEST['ids'])) {
-			$post_ids = explode(',', $_REQUEST['ids']);
+			$ids = wp_unslash($_REQUEST['ids']);
+			$post_ids = is_array($ids) ? $ids : explode(',', (string) $ids);
 		}
 
 		// Make sure ids are submitted.


### PR DESCRIPTION
**Task**:: [Error Report on bulk-actions.php](https://app.clickup.com/t/1867958/86d3c6zkd)

**Description**:: Fixed a `TypeError` in `bulk-actions.php` that occurred when the `ids` parameter was passed as an array instead of a comma-separated string.
Previously, the code directly used `explode(',', $_REQUEST['ids'])`, which caused a fatal error when `$_REQUEST['ids']` was an array.
Updated the logic to support both formats by checking whether the `ids` value is an array or a string before processing it.
This resolves the fatal error encountered when updating category protection through the Simple Membership plugin.

**Before**:: [Link](https://drive.google.com/file/d/1ol45RvchtFBt3HH3uQu9PGDnzZDUCVT6/view?usp=sharing)
**After**:: [Link](https://drive.google.com/file/d/1v84vymbT9NW9RUIiDblEHfeJPfdyeBOs/view?usp=sharing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admin notice handling for selections submitted as arrays or comma-separated values.
  * Correctly processes escaped request data when counting selected posts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->