### PR TITLE
Add to Google Calendar” link breaks for Cyrillic (and all non-Latin) characters

### DIFF
--- a/includes/abstracts/calendar.php
+++ b/includes/abstracts/calendar.php
@@ -790,21 +790,31 @@ abstract class Calendar
 		// "location" (address) should work with an address, just a name or blank.
 		$params = [
 			'action' => 'TEMPLATE',
-			'text' => urlencode(strip_tags($event->title)),
+			'text' => rawurlencode(strip_tags((string) $event->title)),
 			'dates' => $gcal_dt_string,
-			'details' => urlencode($event->description),
-			'location' => urlencode($event->start_location['address']),
+			'details' => rawurlencode(strip_tags((string) $event->description)),
+			'location' => rawurlencode(strip_tags((string) ($event->start_location['address'] ?? ''))),
 			'trp' => 'false',
 		];
 
 		// "ctz" (timezone) arg should be included unless all-day OR 'UTC'.
 		if (!$is_all_day && 'UTC' !== $event->timezone) {
-			$params['ctz'] = urlencode($event->timezone);
+			$params['ctz'] = rawurlencode($event->timezone);
 		}
 
-		$params = array_map('sanitize_text_field', $params);
-
-		$url = esc_url(add_query_arg($params, sanitize_url($base_url)));
+		$url =
+			$base_url .
+			'?' .
+			implode(
+				'&',
+				array_map(
+					function ($k, $v) {
+						return $k . '=' . $v;
+					},
+					array_keys($params),
+					array_values($params),
+				),
+			);
 
 		return $url;
 	}

--- a/includes/events/event-builder.php
+++ b/includes/events/event-builder.php
@@ -988,9 +988,12 @@ class Event_Builder
 		 */
 		$additional_link_atts = apply_filters('simcal_additional_event_link_attributes', '', $attr);
 
+		// esc_url() strips percent-encoded non-ASCII octets; use esc_attr() for gcal links.
+		$href = 'add-to-gcal-link' === $tag ? esc_attr($url) : esc_url($url);
+
 		return false !== $anchor
 			? ' <a href="' .
-					esc_url($url) .
+					$href .
 					'" ' .
 					wp_kses_post($target) .
 					' ' .


### PR DESCRIPTION
**Description:** As per users suggestion I have did apply the fix there were some space issue in users suggestions so I have fix them also.

**Issue:** https://wordpress.org/support/topic/broke-cyrillic-in-add-to-calendar-link/
Before: https://drive.google.com/file/d/12i4EQE-lf5Nne-7c7Kd7OHR5xCArWbdB/view?usp=drivesdk
After:  https://drive.google.com/file/d/1oTfwE5voY6ug0o8jcaHkf5KMOnXHlmhe/view?usp=drivesdk
Clickup: https://app.clickup.com/t/1867958/86d2vcpqb