### PR TITLE
Add Claude PR reviewer

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,27 @@
+# Automated Claude review on every PR open and every push to a PR.
+#
+# All the logic lives in Xtendify/github-workflows. Change the prompt, model, tool
+# allowlist or cost caps there and every consuming repo picks it up — do not fork this
+# file. GitHub only runs workflows stored in this repo's own .github/workflows, which is
+# why this thin caller has to exist at all.
+#
+# Managed by scripts/deploy-claude-pr-reviewer.sh in Xtendify/internal--hub.
+
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  review:
+    uses: Xtendify/github-workflows/.github/workflows/claude-pr-review.yml@main
+    secrets: inherit
+    # A called workflow can never exceed the calling job's token, so the permissions have
+    # to be granted here.
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -16,7 +16,11 @@ on:
 jobs:
   review:
     uses: Xtendify/github-workflows/.github/workflows/claude-pr-review.yml@main
-    secrets: inherit
+    # Named rather than `secrets: inherit`, which would hand the shared workflow every
+    # secret this repo can see. The review job runs Claude with Bash access, so it gets
+    # the one credential it needs and nothing else.
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     # A called workflow can never exceed the calling job's token, so the permissions have
     # to be granted here.
     permissions:

--- a/.github/workflows/claude-responder.yml
+++ b/.github/workflows/claude-responder.yml
@@ -1,0 +1,31 @@
+# Claude answers @claude mentions on pull requests, including replies inside an existing
+# review thread.
+#
+# All the logic lives in Xtendify/github-workflows. Change it there and every consuming
+# repo picks it up — do not fork this file. GitHub only runs workflows stored in this
+# repo's own .github/workflows, which is why this thin caller has to exist at all.
+#
+# Managed by scripts/deploy-claude-pr-reviewer.sh in Xtendify/internal--hub.
+
+name: Claude Responder
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  respond:
+    uses: Xtendify/github-workflows/.github/workflows/claude-responder.yml@main
+    secrets: inherit
+    # A called workflow can never exceed the calling job's token, so the permissions have
+    # to be granted here. `contents: write` because Claude may be asked to push a fix.
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read

--- a/.github/workflows/claude-responder.yml
+++ b/.github/workflows/claude-responder.yml
@@ -20,7 +20,11 @@ on:
 jobs:
   respond:
     uses: Xtendify/github-workflows/.github/workflows/claude-responder.yml@main
-    secrets: inherit
+    # Named rather than `secrets: inherit`, which would hand the shared workflow every
+    # secret this repo can see. The responder runs Claude with Bash access, so it gets
+    # the one credential it needs and nothing else.
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     # A called workflow can never exceed the calling job's token, so the permissions have
     # to be granted here. `contents: write` because Claude may be asked to push a fix.
     permissions:


### PR DESCRIPTION
Adds the two caller workflows that opt this repo into the Claude PR reviewer.

- **Claude PR Review** reviews the diff when a PR opens and on every push to it, posting
  findings as inline comments. It reads the comments already on the PR first, so it does
  not repeat a finding it or a human has already raised.
- **Claude Responder** replies when someone writes `@claude` in a PR comment or in a
  reply inside a review thread.

Both files are thin callers. All the logic — prompt, model, tool allowlist, cost caps —
lives in [`Xtendify/github-workflows`](https://github.com/Xtendify/github-workflows), so change
it there rather than editing these files. GitHub only runs workflows stored in a repo's
own `.github/workflows`, which is why the callers have to exist at all.

Opened by `scripts/deploy-claude-pr-reviewer.sh` in `Xtendify/internal--hub`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated pull request reviews for opened, updated, reopened, and review-ready pull requests.
  * Added an automated responder for issue comments, pull request comments, and submitted reviews.
  * Enabled the required permissions for these automated workflows to inspect repository activity and respond to pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->