### PR TITLE
Add AI PR reviewer

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -1,0 +1,35 @@
+# Automated AI review on every PR open and every push to a PR.
+#
+# All the logic lives in Xtendify/github-workflows. Change the prompt, model, tool
+# allowlist or cost caps there and every consuming repo picks it up — do not fork this
+# file. GitHub only runs workflows stored in this repo's own .github/workflows, which is
+# why this thin caller has to exist at all.
+#
+# Managed by scripts/deploy-ai-pr-reviewer.sh in Xtendify/internal--hub.
+
+name: AI PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  review:
+    uses: Xtendify/github-workflows/.github/workflows/ai-pr-review.yml@main
+    # Named rather than `secrets: inherit`, which would hand the shared workflow every
+    # secret this repo can see. The review job runs an agent with Bash access, so it gets
+    # the one credential it needs and nothing else.
+    secrets:
+      AI_REVIEWER_TOKEN: ${{ secrets.AI_REVIEWER_TOKEN }}
+    # A called workflow can never exceed the calling job's token, so the permissions have
+    # to be granted here.
+    #
+    # `issues` is not dead weight even though this org does not use GitHub issues: a pull
+    # request's top-level comments are served by the issues API, so this is what lets the
+    # reviewer read prior comments and post its summary. Removing it breaks the summary.
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read

--- a/.github/workflows/ai-responder.yml
+++ b/.github/workflows/ai-responder.yml
@@ -1,0 +1,35 @@
+# The reviewer answers @claude mentions on pull requests, including replies inside an existing
+# review thread.
+#
+# All the logic lives in Xtendify/github-workflows. Change it there and every consuming
+# repo picks it up — do not fork this file. GitHub only runs workflows stored in this
+# repo's own .github/workflows, which is why this thin caller has to exist at all.
+#
+# Managed by scripts/deploy-ai-pr-reviewer.sh in Xtendify/internal--hub.
+
+name: AI Responder
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  respond:
+    uses: Xtendify/github-workflows/.github/workflows/ai-responder.yml@main
+    # Named rather than `secrets: inherit`, which would hand the shared workflow every
+    # secret this repo can see. The responder runs an agent with Bash access, so it gets
+    # the one credential it needs and nothing else.
+    secrets:
+      AI_REVIEWER_TOKEN: ${{ secrets.AI_REVIEWER_TOKEN }}
+    # A called workflow can never exceed the calling job's token, so the permissions have
+    # to be granted here. `contents: write` because the agent may be asked to push a fix.
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read


### PR DESCRIPTION
Adds the two caller workflows that opt this repo into the AI PR reviewer.

- **AI PR Review** reviews the diff when a PR opens and on every push to it, posting
  findings as inline comments. It reads the comments already on the PR first, so it does
  not repeat a finding it or a human has already raised.
- **AI Responder** replies when someone writes `@claude` in a PR comment or in a
  reply inside a review thread.

Both files are thin callers. All the logic — prompt, model, tool allowlist, cost caps —
lives in [`Xtendify/github-workflows`](https://github.com/Xtendify/github-workflows), so change
it there rather than editing these files. GitHub only runs workflows stored in a repo's
own `.github/workflows`, which is why the callers have to exist at all.

Opened by `scripts/deploy-ai-pr-reviewer.sh` in `Xtendify/internal--hub`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated AI-assisted pull request reviews when pull requests are opened, updated, reopened, or marked ready.
  * Added an AI responder that can react to issue comments and pull request review activity.
  * Configured the required permissions and authentication for these automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->